### PR TITLE
Define initial CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+
+  check:
+    needs: []
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Set up GitHub Actions"
+      uses: actions/checkout@v2
+    - name: "Set up Python 3.6"
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: "Install Python dependencies"
+      run: |
+        pip install ".[dev]"
+    - name: "Check code format"
+      run: |
+        make check
+
+  test:
+    needs: [check]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+    - name: "Set up GitHub Actions"
+      uses: actions/checkout@v2
+    - name: "Set up Python ${{ matrix.python-version }}"
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: "Install Python dependencies"
+      run: |
+        pip install ".[dev]"
+    - name: "Test with pytest"
+      run: |
+        make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    # Run weekly to check if dependencies broke
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,10 @@ jobs:
 
   test:
     needs: [check]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
     steps:
     - name: "Set up GitHub Actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
         python-version: 3.6
     - name: "Install Python dependencies"
       run: |
-        pip install ".[dev]"
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --quiet --no-cache-dir ".[dev]"
+        python -m pip list
     - name: "Check code format"
       run: |
         make check
@@ -43,7 +45,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: "Install Python dependencies"
       run: |
-        pip install ".[dev]"
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --quiet --no-cache-dir ".[dev]"
+        python -m pip list
     - name: "Test with pytest"
       run: |
         make test


### PR DESCRIPTION
This PR defines the proposed pair of initial _GitHub Actions_ CI jobs, based on the `Makefile` rules that [PR #1](https://github.com/HEPData/hepdata-pyhf-extractor/pull/1) will introduce.

I created this PR separated from [PR #1](https://github.com/HEPData/hepdata-pyhf-extractor/pull/1), in case further discussion occurs.

#### Considerations
- Running the format checker with Python3.6 (I think it does not matter as far as Python3 is used).
- Running the test job on the Python3 versions currently available (3.6, 3.7 and 3.8).

#### Future work
- If HEPData team likes GitHub Actions, future iterations could include other workflows to build and publish particular versions to PyPi (through the use of [secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets)).

