### PR TITLE
Fix CI branch reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   schedule:
     # Run weekly to check if dependencies broke
     - cron: '0 0 * * 0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,24 @@ jobs:
     - name: "Install Python dependencies"
       run: |
         python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --quiet --no-cache-dir ".[ci]"
         python -m pip install --ignore-installed --quiet --no-cache-dir ".[dev]"
         python -m pip list
     - name: "Test with pytest"
       run: |
         make test
+    - name: "Submit partial coverage"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        coveralls
+
+  coverage:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Compute overall coverage"
+      uses: coverallsapp/github-action@v1.1.2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HEPData pyhf extractor
 
-![GH Actions status][badge-actions-status]
+[![GH Actions status][badge-actions-image]][badge-actions-status]
 [![Coverage status][badge-coverage-image]][badge-coverage-status]
 [![Project license][badge-license-image]][badge-license-ref] 
 
@@ -46,7 +46,8 @@ make tag-patch
 ```
 
 
-[badge-actions-status]: https://github.com/HEPData/hepdata-pyhf-extractor/workflows/Continuous%20Integration/badge.svg?branch=main
+[badge-actions-image]: https://github.com/HEPData/hepdata-pyhf-extractor/workflows/Continuous%20Integration/badge.svg?branch=main
+[badge-actions-status]: https://github.com/HEPData/hepdata-pyhf-extractor/actions?query=workflow%3A%22Continuous%20Integration%22+branch%3Amain
 [badge-coverage-image]: https://coveralls.io/repos/github/HEPData/hepdata-pyhf-extractor/badge.svg?branch=main
 [badge-coverage-status]: https://coveralls.io/github/HEPData/hepdata-pyhf-extractor?branch=main
 [badge-license-image]: https://img.shields.io/badge/License-GPL%20v2-blue.svg

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # HEPData pyhf extractor
 
+![GH Actions status][badge-actions-status]
+[![Coverage status](https://coveralls.io/repos/github/HEPData/hepdata-validator/badge.svg)][badge-coverage-status]
+[![Project license](https://img.shields.io/badge/License-GPL%20v2-blue.svg)][badge-project-license] 
+
 Python package to extract and summarize information from the [pyhf][pyhf-repository] submissions.
 
 
@@ -42,6 +46,9 @@ make tag-patch
 ```
 
 
+[badge-actions-status]: https://github.com/HEPData/hepdata-pyhf-extractor/workflows/Continuous%20Integration/badge.svg
+[badge-coverage-status]: https://coveralls.io/github/HEPData/hepdata-pyhf-extractor?branch=main
+[badge-project-license]: https://opensource.org/licenses/GPL-2.0
 [black-web]: https://black.readthedocs.io/en/stable/
 [pre-commit-web]: https://pre-commit.com/
 [pyhf-repository]: https://github.com/scikit-hep/pyhf

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # HEPData pyhf extractor
 
 ![GH Actions status][badge-actions-status]
-[![Coverage status](https://coveralls.io/repos/github/HEPData/hepdata-validator/badge.svg)][badge-coverage-status]
-[![Project license](https://img.shields.io/badge/License-GPL%20v2-blue.svg)][badge-project-license] 
+[![Coverage status][badge-coverage-image]][badge-coverage-status]
+[![Project license][badge-license-image]][badge-license-ref] 
 
 Python package to extract and summarize information from the [pyhf][pyhf-repository] submissions.
 
@@ -46,9 +46,11 @@ make tag-patch
 ```
 
 
-[badge-actions-status]: https://github.com/HEPData/hepdata-pyhf-extractor/workflows/Continuous%20Integration/badge.svg
+[badge-actions-status]: https://github.com/HEPData/hepdata-pyhf-extractor/workflows/Continuous%20Integration/badge.svg?branch=main
+[badge-coverage-image]: https://coveralls.io/repos/github/HEPData/hepdata-pyhf-extractor/badge.svg?branch=main
 [badge-coverage-status]: https://coveralls.io/github/HEPData/hepdata-pyhf-extractor?branch=main
-[badge-project-license]: https://opensource.org/licenses/GPL-2.0
+[badge-license-image]: https://img.shields.io/badge/License-GPL%20v2-blue.svg
+[badge-license-ref]: https://opensource.org/licenses/GPL-2.0
 [black-web]: https://black.readthedocs.io/en/stable/
 [pre-commit-web]: https://pre-commit.com/
 [pyhf-repository]: https://github.com/scikit-hep/pyhf

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,11 @@ DEVELOPMENT_REQS = [
     "pytest-cov>=2.10.0",
 ]
 
+# CI / CD requirements
+INTEGRATION_REQS = [
+    "coveralls>=2.1.2",
+]
+
 
 setup(
     name=NAME,
@@ -39,6 +44,7 @@ setup(
     install_requires=INSTALLATION_REQS,
     extras_require={
         "dev": DEVELOPMENT_REQS,
+        "ci": INTEGRATION_REQS,
     },
     include_package_data=True,
     license="GPLv2",

--- a/src/pyhf_extractor/summarizers/pallet.py
+++ b/src/pyhf_extractor/summarizers/pallet.py
@@ -97,10 +97,12 @@ class V1PalletSummarizer(BasePalletSummarizer):
         :param pallet_data: content of the Pallet file (optional)
         """
 
+        # fmt: off
         assert \
             (pallet_path is not None) or \
             (pallet_data is not None), \
             "Either the Pallet path or the Pallet data must be provided"
+        # fmt: on
 
         if pallet_path is not None:
             data = self.__load_initial_data(pallet_path)


### PR DESCRIPTION
This PR aims to fix a bug introduced in the [CI workflow definition PR](https://github.com/HEPData/hepdata-pyhf-extractor/pull/2), where the _now legacy_ `master` branch, instead of the _new and shiny_ `main` branch, was referenced...

In addition, it adds 3 badges to the README file:
- A **GitHub Actions** status badge.
- A **Coveralls** status badge.
- A **LICENSE** reference badge.

#### Clarifications
- The official _parallel job_ example shown in the the [Coveralls GitHub-action page](https://github.com/marketplace/actions/coveralls-github-action#complete-parallel-job-example) **does not work**.
- The way to make `coveralls` to properly work with parallelized GitHub Actions jobs is to combine the `coveralls` package and the `coverallsapp` action (according to the comments in [this coverallsapp thread](https://github.com/coverallsapp/github-action/issues/4)).
- Both the `coveralls` package and the `coverallsapp` action rely on the `GITHUB_TOKEN` secret (**implicitly** set).